### PR TITLE
feat(contact): Add Contact Us form with email functionality

### DIFF
--- a/api/supabase/functions/sendContactEmail/deno.json
+++ b/api/supabase/functions/sendContactEmail/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "jsr:@supabase/functions-js/edge-runtime.d.ts": "https://esm.sh/@supabase/functions-js@2.1.5/edge-runtime.d.ts"
+  }
+} 

--- a/api/supabase/functions/sendContactEmail/index.ts
+++ b/api/supabase/functions/sendContactEmail/index.ts
@@ -1,0 +1,178 @@
+// Follow this setup guide to integrate the Deno language server with your editor:
+// https://deno.land/manual/getting_started/setup_your_environment
+// This enables autocomplete, go to definition, etc.
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+
+console.log("Hello from sendContactEmail Function!")
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const { name, email, message, attachments } = await req.json()
+
+    // Validate required fields
+    if (!name || !email || !message) {
+      return new Response(
+        JSON.stringify({ error: 'Name, email, and message are required' }),
+        { 
+          status: 400, 
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+        }
+      )
+    }
+
+    // Validate email format
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!emailRegex.test(email)) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid email format' }),
+        { 
+          status: 400, 
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+        }
+      )
+    }
+
+    // Send email using Resend
+    const emailSent = await sendContactEmail(name, email, message, attachments)
+
+    if (emailSent) {
+      return new Response(
+        JSON.stringify({ success: true, message: 'Contact form submitted successfully' }),
+        { 
+          status: 200, 
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+        }
+      )
+    } else {
+      return new Response(
+        JSON.stringify({ error: 'Failed to send email' }),
+        { 
+          status: 500, 
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+        }
+      )
+    }
+
+  } catch (error) {
+    console.error('Error processing contact form:', error)
+    return new Response(
+      JSON.stringify({ error: 'Internal server error' }),
+      { 
+        status: 500, 
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+      }
+    )
+  }
+})
+
+async function sendContactEmail(name: string, email: string, message: string, attachments?: any[]): Promise<boolean> {
+  try {
+    const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY')
+    
+    if (!RESEND_API_KEY) {
+      console.log('Resend API key not configured, simulating email send...')
+      console.log('Contact form submission:', { name, email, message, attachments })
+      return true
+    }
+
+    const htmlContent = generateContactEmailHTML(name, email, message, attachments)
+    const plainTextContent = generatePlainTextContent(htmlContent)
+
+    console.log('Sending contact email from:', email, 'to organizers')
+
+    const response = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${RESEND_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: 'SSSIO Conference Companion <onboarding@resend.dev>',
+        to: ['2025-nc-core-group@sathyasai.us'], // Replace with actual organizer email
+        reply_to: email,
+        subject: `Contact Form Submission from ${name}`,
+        html: htmlContent,
+        text: plainTextContent,
+      }),
+    })
+
+    if (!response.ok) {
+      const error = await response.text()
+      console.error('Resend API error:', error)
+      return false
+    }
+
+    const result = await response.json()
+    console.log('Contact email sent successfully:', result)
+    return true
+  } catch (error) {
+    console.error('Error sending contact email:', error)
+    return false
+  }
+}
+
+function generateContactEmailHTML(name: string, email: string, message: string, attachments?: any[]): string {
+  const hasAttachments = attachments && attachments.length > 0
+  
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Contact Form Submission</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <h2 style="color: #fba758; border-bottom: 2px solid #fba758; padding-bottom: 10px;">
+    New Contact Form Submission
+  </h2>
+  
+  <div style="background-color: #f8f9fa; padding: 15px; border-radius: 5px; margin: 20px 0;">
+    <h3 style="margin-top: 0; color: #333;">Contact Information</h3>
+    <p><strong>Name:</strong> ${name}</p>
+    <p><strong>Email:</strong> ${email}</p>
+    <p><strong>Date:</strong> ${new Date().toLocaleString()}</p>
+  </div>
+
+  <div style="background-color: #fff; padding: 15px; border-left: 4px solid #fba758; margin: 20px 0;">
+    <h3 style="margin-top: 0; color: #333;">Message</h3>
+    <p style="white-space: pre-wrap; line-height: 1.6;">${message}</p>
+  </div>
+
+  ${hasAttachments ? `
+  <div style="background-color: #e8f4fd; padding: 15px; border-radius: 5px; margin: 20px 0;">
+    <h3 style="margin-top: 0; color: #333;">Attachments (${attachments!.length})</h3>
+    ${attachments!.map(attachment => `
+      <p><strong>File:</strong> ${attachment.name || 'Unnamed file'}</p>
+      <p><strong>Type:</strong> ${attachment.type || 'Unknown'}</p>
+      <p><strong>Size:</strong> ${attachment.size ? `${(attachment.size / 1024).toFixed(1)} KB` : 'Unknown'}</p>
+    `).join('')}
+  </div>
+  ` : ''}
+
+  <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #eee; color: #666; font-size: 12px;">
+    <p>This message was sent from the Conference Companion contact form.</p>
+    <p>You can reply directly to this email to respond to ${name}.</p>
+  </div>
+</body>
+</html>`
+}
+
+function generatePlainTextContent(htmlContent: string): string {
+  // Simple HTML to plain text conversion
+  return htmlContent
+    .replace(/<[^>]*>/g, '') // Remove HTML tags
+    .replace(/&nbsp;/g, ' ') // Replace &nbsp; with spaces
+    .replace(/\s+/g, ' ') // Replace multiple spaces with single space
+    .trim()
+} 

--- a/frontend/src/app/api/sendContactEmail/route.ts
+++ b/frontend/src/app/api/sendContactEmail/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { name, email, message, userEmail } = body;
+
+    // Validate required fields
+    if (!name || !email || !message) {
+      return NextResponse.json(
+        { error: 'Missing required fields: name, email, and message are required' },
+        { status: 400 }
+      );
+    }
+
+    // Validate email format
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return NextResponse.json(
+        { error: 'Invalid email format' },
+        { status: 400 }
+      );
+    }
+
+    // Call Supabase function to send email
+    const response = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/sendContactEmail`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY}`,
+      },
+      body: JSON.stringify({
+        name,
+        email,
+        message,
+        userEmail
+      }),
+    });
+
+    const contentType = response.headers.get('content-type');
+    let data;
+    if (contentType && contentType.includes('application/json')) {
+      data = await response.json();
+    } else {
+      const text = await response.text();
+      data = { error: text };
+    }
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: data.error || 'Failed to send contact email' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Send contact email error:', error);
+    return NextResponse.json(
+      { error: 'Network error. Please check your connection and try again.' },
+      { status: 500 }
+    );
+  }
+} 

--- a/frontend/src/app/contact/page.tsx
+++ b/frontend/src/app/contact/page.tsx
@@ -1,0 +1,253 @@
+"use client";
+import React, { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import MenuDropdown from "@/components/MenuDropdown";
+import { AdminStatus } from "@/utils/admin";
+import { User } from "@/utils/types";
+import { createMenuOptions } from "@/utils/menu";
+import { getUserFromStorage, checkAdminStatus, handleLogout } from "@/utils/auth";
+import { LoadingScreen } from "@/utils/ui";
+import BackgroundImage from '@/components/BackgroundImage';
+
+export default function ContactPage() {
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [adminStatus, setAdminStatus] = useState<AdminStatus | null>(null);
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    message: ''
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitStatus, setSubmitStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    // Check if user is logged in
+    const userObj = getUserFromStorage();
+    if (!userObj) {
+      router.push('/');
+      return;
+    }
+    setUser(userObj);
+    
+    // Pre-fill form with user data
+    setFormData(prev => ({
+      ...prev,
+      name: `${userObj.firstName} ${userObj.lastName}`,
+      email: userObj.email
+    }));
+    
+    // Check admin status
+    checkAdminStatus(userObj.email).then(setAdminStatus);
+  }, [router]);
+
+  const handleLogoutClick = () => handleLogout(router);
+
+  const menuOptions = createMenuOptions({
+    currentPage: 'contact',
+    router,
+    handleLogout: handleLogoutClick,
+    adminStatus,
+  });
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!formData.name.trim() || !formData.email.trim() || !formData.message.trim()) {
+      setErrorMessage('Please fill in all required fields.');
+      setSubmitStatus('error');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitStatus('idle');
+    setErrorMessage('');
+
+    try {
+      const response = await fetch('/api/sendContactEmail', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: formData.name.trim(),
+          email: formData.email.trim(),
+          message: formData.message.trim(),
+          userEmail: user?.email
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to send message');
+      }
+
+      setSubmitStatus('success');
+      setFormData({
+        name: `${user?.firstName} ${user?.lastName}` || '',
+        email: user?.email || '',
+        message: ''
+      });
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : 'Failed to send message. Please try again.');
+      setSubmitStatus('error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!user) {
+    return <LoadingScreen />;
+  }
+
+  return (
+    <div className="h-screen bg-white flex flex-col px-4 py-6 relative overflow-hidden">
+      <BackgroundImage />
+      {/* Header with title and menu */}
+      <div className="mb-6">
+        {/* Top row: Logo and Menu */}
+        <div className="flex justify-between items-center mb-4">
+          <Image 
+            src="/assets/conference-companion.png" 
+            alt="Conference Companion" 
+            width={48}
+            height={48}
+          />
+          <MenuDropdown 
+            options={menuOptions} 
+            userName={`${user.firstName} ${user.lastName}`}
+          />
+        </div>
+        
+        {/* Bottom row: Title and subtitle */}
+        <div className="max-w-2xl">
+          <h1 className="text-3xl font-bold text-[#fba758] mb-2" style={{ letterSpacing: 0.5 }}>
+            Contact Us
+          </h1>
+          <p className="text-lg text-gray-600">
+            Get in touch with the conference organizers
+          </p>
+        </div>
+      </div>
+
+      {/* Main content */}
+      <div className="relative z-10 flex-1 flex flex-col w-full max-w-2xl mx-auto">
+        <div className="bg-white/80 backdrop-blur-sm rounded-xl p-8 shadow-lg border border-gray-100">
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* Friendly message */}
+            <div className="text-center mb-6">
+              <p className="text-base text-gray-600">
+                We're here to help! Please share any questions, feedback, or concerns you may have. Our team is ready to listen and assist you.
+              </p>
+            </div>
+
+            {/* Name Field */}
+            <div>
+              <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
+                Your Name *
+              </label>
+              <input
+                type="text"
+                id="name"
+                name="name"
+                value={formData.name}
+                onChange={handleInputChange}
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fba758] focus:border-transparent transition-colors"
+                placeholder="Your full name"
+                required
+              />
+            </div>
+
+            {/* Email Field */}
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+                Your Email *
+              </label>
+              <input
+                type="email"
+                id="email"
+                name="email"
+                value={formData.email}
+                onChange={handleInputChange}
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fba758] focus:border-transparent transition-colors"
+                placeholder="your.email@example.com"
+                required
+              />
+            </div>
+
+            {/* Message Field */}
+            <div>
+              <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-2">
+                Your Message *
+              </label>
+              <textarea
+                id="message"
+                name="message"
+                value={formData.message}
+                onChange={handleInputChange}
+                rows={6}
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#fba758] focus:border-transparent transition-colors resize-none"
+                placeholder="Tell us about your question, feedback, or concern..."
+                required
+              />
+            </div>
+
+            {/* Submit Button */}
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="bg-[#fba758] text-white px-8 py-3 rounded-lg font-semibold hover:bg-[#fba758]/90 transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed flex items-center gap-2"
+              >
+                {isSubmitting ? (
+                  <>
+                    <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
+                    Sending...
+                  </>
+                ) : (
+                  'Send Message'
+                )}
+              </button>
+            </div>
+
+            {/* Status Messages */}
+            {submitStatus === 'success' && (
+              <div className="p-4 bg-green-50 border border-green-200 rounded-lg">
+                <div className="flex items-center gap-2">
+                  <div className="text-green-600">✅</div>
+                  <p className="text-green-800 font-medium">Message sent successfully!</p>
+                </div>
+                <p className="text-green-700 text-sm mt-1">
+                  We'll get back to you as soon as possible.
+                </p>
+              </div>
+            )}
+
+            {submitStatus === 'error' && (
+              <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
+                <div className="flex items-center gap-2">
+                  <div className="text-red-600">❌</div>
+                  <p className="text-red-800 font-medium">Failed to send message</p>
+                </div>
+                <p className="text-red-700 text-sm mt-1">
+                  {errorMessage}
+                </p>
+              </div>
+            )}
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/frontend/src/utils/menu.ts
+++ b/frontend/src/utils/menu.ts
@@ -11,7 +11,7 @@ export interface MenuOption {
 }
 
 export interface MenuConfig {
-  currentPage: 'home' | 'dashboard' | 'sessions' | 'history' | 'how-it-works' | 'admin';
+  currentPage: 'home' | 'dashboard' | 'sessions' | 'history' | 'how-it-works' | 'admin' | 'contact';
   router: {
     push: (path: string) => void;
   };
@@ -77,5 +77,13 @@ export const createMenuOptions = (config: MenuConfig): MenuOption[] => {
     isDanger: true,
   };
 
-  return [...baseOptions, ...adminOption, logoutOption];
+  const contactOption: MenuOption = {
+    id: 'contact',
+    label: 'Contact Us',
+    emoji: '',
+    action: currentPage === 'contact' ? () => {} : () => router.push('/contact'),
+    isCurrent: currentPage === 'contact',
+  };
+
+  return [...baseOptions, contactOption, ...adminOption, logoutOption];
 }; 


### PR DESCRIPTION
- Add Contact Us page with form for name, email, and message
- Create Supabase function to send contact emails via Resend
- Add API route to handle contact form submissions
- Update menu to include Contact Us option (separate from admin)
- Add friendly messaging and improved field labels
- Use simplified HTML email template
- Send emails to 2025-nc-core-group@sathyasai.us