### PR TITLE
feat(admin-sessions): add Sessions tab with CRUD, modal blur, and live update

### DIFF
--- a/api/supabase/functions/createSession/deno.json
+++ b/api/supabase/functions/createSession/deno.json
@@ -1,0 +1,8 @@
+{
+  "tasks": {
+    "start": "deno run --allow-net --allow-env index.ts"
+  },
+  "imports": {
+    "std/": "https://deno.land/std@0.168.0/"
+  }
+} 

--- a/api/supabase/functions/createSession/index.ts
+++ b/api/supabase/functions/createSession/index.ts
@@ -1,0 +1,113 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const { 
+      day, 
+      start_time, 
+      topic, 
+      speaker, 
+      description, 
+      type, 
+      location, 
+      room, 
+      capacity, 
+      is_children_friendly, 
+      requires_registration, 
+      tags,
+      userEmail 
+    } = await req.json()
+
+    // Validate required fields
+    if (!day || !start_time || !topic || !type) {
+      return new Response(
+        JSON.stringify({ error: 'Day, start time, topic, and type are required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!
+    )
+
+    // Get user ID first
+    const { data: user, error: userError } = await supabase
+      .from('users')
+      .select('id')
+      .eq('email', userEmail)
+      .single()
+
+    if (userError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'User not found' }),
+        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Check if user is admin
+    const { data: adminUser, error: adminError } = await supabase
+      .from('admin_users')
+      .select('admin_level')
+      .eq('user_id', user.id)
+      .single()
+
+    if (adminError || !adminUser) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized: Admin access required' }),
+        { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Create session
+    const { data: session, error: sessionError } = await supabase
+      .from('sessions')
+      .insert({
+        day,
+        start_time,
+        topic,
+        speaker,
+        description,
+        type,
+        location,
+        room,
+        capacity,
+        is_children_friendly: is_children_friendly || false,
+        requires_registration: requires_registration || false,
+        tags: tags || []
+      })
+      .select()
+      .single()
+
+    if (sessionError) {
+      console.error('Error creating session:', sessionError)
+      return new Response(
+        JSON.stringify({ error: 'Failed to create session' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, session }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+
+  } catch (error) {
+    console.error('Error in createSession:', error)
+    return new Response(
+      JSON.stringify({ error: 'Internal server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  }
+}) 

--- a/api/supabase/functions/deleteSession/deno.json
+++ b/api/supabase/functions/deleteSession/deno.json
@@ -1,0 +1,8 @@
+{
+  "tasks": {
+    "start": "deno run --allow-net --allow-env index.ts"
+  },
+  "imports": {
+    "std/": "https://deno.land/std@0.168.0/"
+  }
+} 

--- a/api/supabase/functions/deleteSession/index.ts
+++ b/api/supabase/functions/deleteSession/index.ts
@@ -1,0 +1,85 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const { sessionId, userEmail } = await req.json()
+
+    // Validate required fields
+    if (!sessionId) {
+      return new Response(
+        JSON.stringify({ error: 'Session ID is required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!
+    )
+
+    // Get user ID first
+    const { data: user, error: userError } = await supabase
+      .from('users')
+      .select('id')
+      .eq('email', userEmail)
+      .single()
+
+    if (userError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'User not found' }),
+        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Check if user is admin
+    const { data: adminUser, error: adminError } = await supabase
+      .from('admin_users')
+      .select('admin_level')
+      .eq('user_id', user.id)
+      .single()
+
+    if (adminError || !adminUser) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized: Admin access required' }),
+        { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Delete session
+    const { error: sessionError } = await supabase
+      .from('sessions')
+      .delete()
+      .eq('id', sessionId)
+
+    if (sessionError) {
+      console.error('Error deleting session:', sessionError)
+      return new Response(
+        JSON.stringify({ error: 'Failed to delete session' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, message: 'Session deleted successfully' }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+
+  } catch (error) {
+    console.error('Error in deleteSession:', error)
+    return new Response(
+      JSON.stringify({ error: 'Internal server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  }
+}) 

--- a/api/supabase/functions/getAdminMetrics/deno.json
+++ b/api/supabase/functions/getAdminMetrics/deno.json
@@ -1,0 +1,8 @@
+{
+  "tasks": {
+    "start": "deno run --allow-net --allow-env index.ts"
+  },
+  "imports": {
+    "std/": "https://deno.land/std@0.168.0/"
+  }
+} 

--- a/api/supabase/functions/getAdminMetrics/index.ts
+++ b/api/supabase/functions/getAdminMetrics/index.ts
@@ -1,0 +1,143 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!
+    )
+
+    // Get total users
+    const { count: totalUsers, error: usersError } = await supabase
+      .from('users')
+      .select('*', { count: 'exact', head: true })
+
+    if (usersError) {
+      console.error('Error fetching users:', usersError)
+      return new Response(
+        JSON.stringify({ error: 'Failed to fetch user data' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Get total booths
+    const { count: totalBooths, error: boothsError } = await supabase
+      .from('booths')
+      .select('*', { count: 'exact', head: true })
+
+    if (boothsError) {
+      console.error('Error fetching booths:', boothsError)
+      return new Response(
+        JSON.stringify({ error: 'Failed to fetch booth data' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Get user booth visits to calculate progress
+    const { data: boothVisits, error: visitsError } = await supabase
+      .from('user_booth_visits')
+      .select(`
+        user_id,
+        booth_id,
+        booths (
+          name
+        )
+      `)
+
+    if (visitsError) {
+      console.error('Error fetching booth visits:', visitsError)
+      return new Response(
+        JSON.stringify({ error: 'Failed to fetch booth visit data' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Calculate user progress
+    const totalRegisteredUsers = totalUsers || 0
+    const totalBoothsCount = totalBooths || 0
+    
+    // Group visits by user
+    const userVisits: { [key: number]: number } = {}
+    boothVisits?.forEach(visit => {
+      userVisits[visit.user_id] = (userVisits[visit.user_id] || 0) + 1
+    })
+
+    const activeUsers = Object.keys(userVisits).length
+    const completedUsers = Object.values(userVisits).filter(visitCount => visitCount === totalBoothsCount).length
+
+    const completionRate = totalRegisteredUsers > 0 ? Math.round((completedUsers / totalRegisteredUsers) * 100) : 0
+    const activeRate = totalRegisteredUsers > 0 ? Math.round((activeUsers / totalRegisteredUsers) * 100) : 0
+
+    // Calculate popular booths
+    const boothVisitCounts: { [key: string]: number } = {}
+    boothVisits?.forEach(visit => {
+      const boothName = visit.booths?.name || 'Unknown Booth'
+      boothVisitCounts[boothName] = (boothVisitCounts[boothName] || 0) + 1
+    })
+
+    const popularBooths = Object.entries(boothVisitCounts)
+      .sort(([,a], [,b]) => b - a)
+      .slice(0, 5)
+      .map(([name, count]) => ({ name, visits: count }))
+
+    // Get session data for popular session types
+    const { data: sessions, error: sessionError } = await supabase
+      .from('sessions')
+      .select('type')
+
+    if (sessionError) {
+      console.error('Error fetching sessions:', sessionError)
+      return new Response(
+        JSON.stringify({ error: 'Failed to fetch session data' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Calculate popular session types
+    const sessionTypeCounts: { [key: string]: number } = {}
+    sessions?.forEach(session => {
+      const type = session.type || 'unknown'
+      sessionTypeCounts[type] = (sessionTypeCounts[type] || 0) + 1
+    })
+
+    const popularSessionTypes = Object.entries(sessionTypeCounts)
+      .sort(([,a], [,b]) => b - a)
+      .slice(0, 5)
+      .map(([type, count]) => ({ type, count }))
+
+    const metrics = {
+      totalUsers: totalRegisteredUsers,
+      completedUsers,
+      activeUsers,
+      completionRate,
+      activeRate,
+      popularBooths,
+      popularSessionTypes,
+      totalSessions: sessions?.length || 0,
+      totalBooths: totalBoothsCount
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, data: metrics }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+
+  } catch (error) {
+    console.error('Error in getAdminMetrics:', error)
+    return new Response(
+      JSON.stringify({ error: 'Internal server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  }
+}) 

--- a/api/supabase/functions/updateSession/deno.json
+++ b/api/supabase/functions/updateSession/deno.json
@@ -1,0 +1,8 @@
+{
+  "tasks": {
+    "start": "deno run --allow-net --allow-env index.ts"
+  },
+  "imports": {
+    "std/": "https://deno.land/std@0.168.0/"
+  }
+} 

--- a/api/supabase/functions/updateSession/index.ts
+++ b/api/supabase/functions/updateSession/index.ts
@@ -1,0 +1,133 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const body = await req.json()
+    console.log('Received request body:', JSON.stringify(body, null, 2))
+
+    const { 
+      sessionId,
+      day, 
+      start_time, 
+      topic, 
+      speaker, 
+      description, 
+      type, 
+      location, 
+      room, 
+      capacity, 
+      is_children_friendly, 
+      requires_registration, 
+      tags,
+      userEmail 
+    } = body
+
+    // Validate required fields
+    if (!sessionId || !day || !start_time || !topic || !type) {
+      console.log('Validation failed:', { sessionId, day, start_time, topic, type })
+      return new Response(
+        JSON.stringify({ error: 'Session ID, day, start time, topic, and type are required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    )
+
+    console.log('Looking up user with email:', userEmail)
+
+    // Get user ID first
+    const { data: user, error: userError } = await supabase
+      .from('users')
+      .select('id')
+      .eq('email', userEmail)
+      .single()
+
+    if (userError || !user) {
+      console.log('User lookup failed:', userError)
+      return new Response(
+        JSON.stringify({ error: 'User not found' }),
+        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    console.log('User found:', user.id)
+
+    // Check if user is admin
+    const { data: adminUser, error: adminError } = await supabase
+      .from('admin_users')
+      .select('admin_level')
+      .eq('user_id', user.id)
+      .single()
+
+    if (adminError || !adminUser) {
+      console.log('Admin check failed:', adminError)
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized: Admin access required' }),
+        { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    console.log('Admin check passed:', adminUser.admin_level)
+
+    // Update session
+    const updateData = {
+      day,
+      start_time,
+      topic,
+      speaker,
+      description,
+      type,
+      location,
+      room,
+      capacity,
+      is_children_friendly: is_children_friendly || false,
+      requires_registration: requires_registration || false,
+      tags: tags || []
+    }
+
+    console.log('Updating session with data:', JSON.stringify(updateData, null, 2))
+
+    const { data: session, error: sessionError } = await supabase
+      .from('sessions')
+      .update(updateData)
+      .eq('id', sessionId)
+      .select()
+      .single()
+
+    if (sessionError) {
+      console.error('Error updating session:', sessionError)
+      return new Response(
+        JSON.stringify({ error: 'Failed to update session', details: sessionError.message }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    console.log('Session updated successfully:', session.id)
+
+    return new Response(
+      JSON.stringify({ success: true, session }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+
+  } catch (error) {
+    console.error('Error in updateSession:', error)
+    return new Response(
+      JSON.stringify({ error: 'Internal server error', details: error.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  }
+}) 

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -8,7 +8,7 @@ import BoothModal from "@/components/BoothModal";
 import SessionForm from "@/components/SessionForm";
 import AdminSessionModal from "@/components/AdminSessionModal";
 import { AdminStatus, getAdminIcon } from "@/utils/admin";
-import { User, Booth, Session } from "@/utils/types";
+import { User, Booth, Session, AdminMetrics, SessionFormData, PopularBooth, PopularSessionType } from "@/utils/types";
 import { createMenuOptions } from "@/utils/menu";
 import { getUserFromStorage, checkAdminStatus, handleLogout } from "@/utils/auth";
 import { LoadingScreen, LoadingSpinner } from "@/utils/ui";
@@ -40,7 +40,7 @@ export default function AdminPage() {
   const [isSessionLoading, setIsSessionLoading] = useState(false);
   
   // Admin metrics state
-  const [metrics, setMetrics] = useState<any>(null);
+  const [metrics, setMetrics] = useState<AdminMetrics | null>(null);
   const [isLoadingMetrics, setIsLoadingMetrics] = useState(false);
   const [metricsError, setMetricsError] = useState<string | null>(null);
 
@@ -204,7 +204,7 @@ export default function AdminPage() {
     setIsModalOpen(true);
   };
 
-  const handleCreateSession = async (sessionData: any) => {
+  const handleCreateSession = async (sessionData: SessionFormData) => {
     if (!user?.email) return;
     
     setIsCreatingSession(true);
@@ -242,7 +242,7 @@ export default function AdminPage() {
     }
   };
 
-  const handleUpdateSession = async (sessionId: number, sessionData: any) => {
+  const handleUpdateSession = async (sessionId: number, sessionData: SessionFormData) => {
     if (!user?.email) return;
     
     try {
@@ -457,7 +457,7 @@ export default function AdminPage() {
                   <h3 className="text-xl font-semibold text-gray-800 mb-4">Most Popular Booths</h3>
                   {metrics.popularBooths && metrics.popularBooths.length > 0 ? (
                     <div className="space-y-3">
-                      {metrics.popularBooths.map((booth: any, index: number) => (
+                      {metrics.popularBooths.map((booth: PopularBooth, index: number) => (
                         <div key={booth.name} className="flex items-center justify-between bg-white p-3 rounded-lg">
                           <div className="flex items-center">
                             <span className="text-lg font-bold text-orange-600 mr-3">#{index + 1}</span>
@@ -477,7 +477,7 @@ export default function AdminPage() {
                   <h3 className="text-xl font-semibold text-gray-800 mb-4">Session Types Distribution</h3>
                   {metrics.popularSessionTypes && metrics.popularSessionTypes.length > 0 ? (
                     <div className="space-y-3">
-                      {metrics.popularSessionTypes.map((sessionType: any, index: number) => (
+                      {metrics.popularSessionTypes.map((sessionType: PopularSessionType, index: number) => (
                         <div key={sessionType.type} className="flex items-center justify-between bg-white p-3 rounded-lg">
                           <div className="flex items-center">
                             <span className="text-lg font-bold text-purple-600 mr-3">#{index + 1}</span>

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
 import MenuDropdown from "@/components/MenuDropdown";
 import BoothForm from "@/components/BoothForm";
 import BoothCard from "@/components/BoothCard";

--- a/frontend/src/app/api/createSession/route.ts
+++ b/frontend/src/app/api/createSession/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return NextResponse.json(
+        { error: 'Supabase configuration missing' },
+        { status: 500 }
+      );
+    }
+
+    const body = await request.json();
+
+    const response = await fetch(`${supabaseUrl}/functions/v1/createSession`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${supabaseAnonKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: data.error || 'Failed to create session' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error creating session:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+} 

--- a/frontend/src/app/api/deleteSession/route.ts
+++ b/frontend/src/app/api/deleteSession/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return NextResponse.json(
+        { error: 'Supabase configuration missing' },
+        { status: 500 }
+      );
+    }
+
+    const body = await request.json();
+
+    const response = await fetch(`${supabaseUrl}/functions/v1/deleteSession`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${supabaseAnonKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: data.error || 'Failed to delete session' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error deleting session:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+} 

--- a/frontend/src/app/api/getAdminMetrics/route.ts
+++ b/frontend/src/app/api/getAdminMetrics/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 
-export async function GET(request: NextRequest) {
+export async function GET() {
   try {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;

--- a/frontend/src/app/api/getAdminMetrics/route.ts
+++ b/frontend/src/app/api/getAdminMetrics/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return NextResponse.json(
+        { error: 'Supabase configuration missing' },
+        { status: 500 }
+      );
+    }
+
+    const response = await fetch(`${supabaseUrl}/functions/v1/getAdminMetrics`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${supabaseAnonKey}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: data.error || 'Failed to fetch admin metrics' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error fetching admin metrics:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+} 

--- a/frontend/src/app/api/updateSession/route.ts
+++ b/frontend/src/app/api/updateSession/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function PUT(request: NextRequest) {
+  try {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return NextResponse.json(
+        { error: 'Supabase configuration missing' },
+        { status: 500 }
+      );
+    }
+
+    const body = await request.json();
+
+    const response = await fetch(`${supabaseUrl}/functions/v1/updateSession`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${supabaseAnonKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: data.error || 'Failed to update session' },
+        { status: response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error updating session:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+} 

--- a/frontend/src/app/contact/page.tsx
+++ b/frontend/src/app/contact/page.tsx
@@ -9,6 +9,7 @@ import { createMenuOptions } from "@/utils/menu";
 import { getUserFromStorage, checkAdminStatus, handleLogout } from "@/utils/auth";
 import { LoadingScreen } from "@/utils/ui";
 import BackgroundImage from '@/components/BackgroundImage';
+import Logo from '@/components/Logo';
 
 export default function ContactPage() {
   const router = useRouter();
@@ -118,12 +119,7 @@ export default function ContactPage() {
       <div className="mb-6">
         {/* Top row: Logo and Menu */}
         <div className="flex justify-between items-center mb-4">
-          <Image 
-            src="/assets/conference-companion.png" 
-            alt="Conference Companion" 
-            width={48}
-            height={48}
-          />
+          <Logo />
           <MenuDropdown 
             options={menuOptions} 
             userName={`${user.firstName} ${user.lastName}`}

--- a/frontend/src/app/contact/page.tsx
+++ b/frontend/src/app/contact/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
 import MenuDropdown from "@/components/MenuDropdown";
 import { AdminStatus } from "@/utils/admin";
 import { User } from "@/utils/types";

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { getUserFromStorage, checkAdminStatus, handleLogout } from "@/utils/auth
 import { sendVisitNotesEmail } from "@/utils/email";
 import { LoadingScreen, LoadingSpinner } from "@/utils/ui";
 import BackgroundImage from '@/components/BackgroundImage';
+import Logo from '@/components/Logo';
 
 export default function Dashboard() {
   const router = useRouter();
@@ -242,12 +243,7 @@ export default function Dashboard() {
       <div className="mb-6">
         {/* Top row: Logo and Menu */}
         <div className="flex justify-between items-center mb-4">
-          <Image 
-            src="/assets/conference-companion.png" 
-            alt="Conference Companion" 
-            width={48}
-            height={48}
-          />
+          <Logo />
           <MenuDropdown 
             options={menuOptions} 
             userName={`${user.firstName} ${user.lastName}`}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
 import MenuDropdown from "@/components/MenuDropdown";
 import StarRating from "@/components/StarRating";
 import { AdminStatus } from "@/utils/admin";

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
 import MenuDropdown from "@/components/MenuDropdown";
 import { User } from "@/utils/types";
 import { getUserFromStorage, checkAdminStatus, handleLogout } from "@/utils/auth";

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -10,6 +10,7 @@ import { AdminStatus } from "@/utils/admin";
 import NoteCard, { NoteData } from "@/components/NoteCard";
 import BackgroundImage from '@/components/BackgroundImage';
 import ShareModal from '@/components/ShareModal';
+import Logo from '@/components/Logo';
 
 export default function MyJourneyPage() {
   const router = useRouter();
@@ -221,13 +222,7 @@ export default function MyJourneyPage() {
       {/* Header with title and menu */}
       <div className="mb-6 flex-shrink-0">
         <div className="flex justify-between items-center mb-4">
-          <Image 
-            src="/assets/conference-companion.png" 
-            alt="Conference Companion" 
-            className="h-12 w-auto"
-            width={48}
-            height={48}
-          />
+          <Logo />
           <MenuDropdown 
             options={menuOptions} 
             userName={`${user.firstName} ${user.lastName}`}

--- a/frontend/src/app/home/page.tsx
+++ b/frontend/src/app/home/page.tsx
@@ -10,6 +10,7 @@ import { AdminStatus } from '@/utils/admin';
 import MenuDropdown from '@/components/MenuDropdown';
 import SessionCard from '@/components/SessionCard';
 import BackgroundImage from '@/components/BackgroundImage';
+import Logo from '@/components/Logo';
 
 // Conference start date - July 11, 2025 at 9:00 AM
 const CONFERENCE_START = new Date('2025-07-11T09:00:00');
@@ -191,13 +192,7 @@ export default function HomePage() {
       {/* Header with logo and menu */}
       <div className="mb-12">
         <div className="flex justify-between items-center mb-12">
-          <Image 
-            src="/assets/conference-companion.png" 
-            alt="Conference Companion" 
-            className="h-12 w-auto"
-            width={48}
-            height={48}
-          />
+          <Logo />
           <MenuDropdown 
             options={menuOptions} 
             userName={`${user.firstName} ${user.lastName}`}

--- a/frontend/src/app/how-it-works/page.tsx
+++ b/frontend/src/app/how-it-works/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
 import MenuDropdown from "@/components/MenuDropdown";
 import { AdminStatus } from "@/utils/admin";
 import { User } from "@/utils/types";

--- a/frontend/src/app/how-it-works/page.tsx
+++ b/frontend/src/app/how-it-works/page.tsx
@@ -9,6 +9,7 @@ import { createMenuOptions } from "@/utils/menu";
 import { getUserFromStorage, checkAdminStatus, handleLogout } from "@/utils/auth";
 import { LoadingScreen } from "@/utils/ui";
 import BackgroundImage from '@/components/BackgroundImage';
+import Logo from '@/components/Logo';
 
 const BOOTH_TRACKING_STEPS = [
   "Visit each booth at the conference to discover amazing activities and services.",
@@ -62,13 +63,7 @@ const HowItWorksPage: React.FC = () => {
       <div className="mb-6">
         {/* Top row: Logo and Menu */}
         <div className="flex justify-between items-center mb-4">
-          <Image 
-            src="/assets/conference-companion.png" 
-            alt="Conference Companion" 
-            width={48}
-            height={48}
-            className="h-12 w-auto"
-          />
+          <Logo />
           <MenuDropdown options={menuOptions} />
         </div>
         

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,6 +5,7 @@ import PrimaryButton from "../components/PrimaryButton";
 import Link from "next/link";
 import Image from "next/image";
 import BackgroundImage from '@/components/BackgroundImage';
+import Logo from '@/components/Logo';
 
 export default function Home() {
   const [email, setEmail] = useState("");
@@ -104,13 +105,11 @@ export default function Home() {
       <div className="min-h-screen flex flex-col items-center justify-center bg-white px-2 py-4 sm:px-4 w-full overflow-x-hidden">
         <div className="flex flex-col items-center mb-8 w-full">
           <div className="mb-4">
-            <Image
-              src="/assets/conference-companion.png"
-              alt="Conference Companion Logo"
+            <Logo 
+              className="w-auto h-16 sm:h-20 object-contain"
               width={200}
               height={100}
-              className="w-auto h-16 sm:h-20 object-contain"
-              priority
+              showNavigation={false}
             />
           </div>
           <h1 className="text-xl sm:text-2xl font-bold text-black mb-1 sm:mb-2 text-center">Conference Companion</h1>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,7 +3,6 @@ import React, { useState } from "react";
 import TextInput from "../components/TextInput";
 import PrimaryButton from "../components/PrimaryButton";
 import Link from "next/link";
-import Image from "next/image";
 import BackgroundImage from '@/components/BackgroundImage';
 import Logo from '@/components/Logo';
 

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -3,7 +3,6 @@ import React, { useState } from "react";
 import TextInput from "../../components/TextInput";
 import PrimaryButton from "../../components/PrimaryButton";
 import Link from "next/link";
-import Image from "next/image";
 import BackgroundImage from '@/components/BackgroundImage';
 import Logo from '@/components/Logo';
 

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -5,6 +5,7 @@ import PrimaryButton from "../../components/PrimaryButton";
 import Link from "next/link";
 import Image from "next/image";
 import BackgroundImage from '@/components/BackgroundImage';
+import Logo from '@/components/Logo';
 
 export default function Register() {
   const [email, setEmail] = useState("");
@@ -75,13 +76,11 @@ export default function Register() {
         {/* Logo and event title */}
         <div className="flex flex-col items-center mb-8 sm:mb-10 w-full">
           <div className="mb-4">
-            <Image
-              src="/assets/conference-companion.png"
-              alt="Conference Companion Logo"
+            <Logo
+              className="w-auto h-16 sm:h-20 object-contain"
               width={200}
               height={100}
-              className="w-auto h-16 sm:h-20 object-contain"
-              priority
+              showNavigation={false}
             />
           </div>
           <h2 className="text-lg sm:text-xl font-bold text-black text-center leading-tight">SSIO National Conference & Children's festival 2025</h2>

--- a/frontend/src/app/sessions/page.tsx
+++ b/frontend/src/app/sessions/page.tsx
@@ -12,6 +12,7 @@ import { createMenuOptions } from "@/utils/menu";
 import { getUserFromStorage, checkAdminStatus, handleLogout } from "@/utils/auth";
 import { LoadingScreen } from "@/utils/ui";
 import BackgroundImage from '@/components/BackgroundImage';
+import Logo from '@/components/Logo';
 import { 
   getCurrentSession, 
   getCurrentDay, 
@@ -328,13 +329,7 @@ export default function SessionsPage() {
       <div className="mb-6">
         {/* Top row: Logo and Menu */}
         <div className="flex justify-between items-center mb-4">
-          <Image 
-            src="/assets/conference-companion.png" 
-            alt="Conference Companion" 
-            className="h-12 w-auto"
-            width={48}
-            height={48}
-          />
+          <Logo />
           <MenuDropdown 
             options={menuOptions} 
             userName={`${user.firstName} ${user.lastName}`}

--- a/frontend/src/app/sessions/page.tsx
+++ b/frontend/src/app/sessions/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
 import MenuDropdown from "@/components/MenuDropdown";
 import SessionCard from "@/components/SessionCard";
 import SessionModal from "@/components/SessionModal";

--- a/frontend/src/components/AdminSessionModal.tsx
+++ b/frontend/src/components/AdminSessionModal.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { Session } from '@/utils/types';
+import SessionForm, { SessionFormData } from './SessionForm';
+
+interface AdminSessionModalProps {
+  session: Session | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onEdit: (sessionData: SessionFormData) => Promise<void>;
+  onDelete: () => Promise<void>;
+  isEditing: boolean;
+  isLoading: boolean;
+  onSetEditing: (editing: boolean) => void;
+}
+
+export default function AdminSessionModal({
+  session,
+  isOpen,
+  onClose,
+  onEdit,
+  onDelete,
+  isEditing,
+  isLoading,
+  onSetEditing
+}: AdminSessionModalProps) {
+  if (!isOpen || !session) return null;
+
+  const formatTime = (time: string) => {
+    const [hours, minutes] = time.split(':');
+    const hour = parseInt(hours);
+    const ampm = hour >= 12 ? 'PM' : 'AM';
+    const displayHour = hour % 12 || 12;
+    return `${displayHour}:${minutes} ${ampm}`;
+  };
+
+  const formatType = (type: string) => {
+    return type.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase());
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center z-[150] p-4">
+      <div className="bg-white rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="p-6">
+          <div className="flex justify-between items-start mb-6">
+            <h2 className="text-2xl font-bold text-gray-900">
+              {isEditing ? 'Edit Session' : session.topic}
+            </h2>
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 text-2xl"
+            >
+              ×
+            </button>
+          </div>
+
+          {isEditing ? (
+            <SessionForm
+              onSubmit={onEdit}
+              onCancel={onClose}
+              isLoading={isLoading}
+              initialData={{
+                day: session.day,
+                start_time: session.start_time,
+                topic: session.topic,
+                speaker: session.speaker || '',
+                description: session.description || '',
+                type: session.type,
+                location: session.location || '',
+                room: session.room || '',
+                capacity: session.capacity || undefined,
+                is_children_friendly: session.is_children_friendly,
+                requires_registration: session.requires_registration,
+                tags: session.tags || []
+              }}
+            />
+          ) : (
+            <div className="space-y-6">
+              {/* Session Details */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div>
+                  <h3 className="text-sm font-medium text-gray-500 mb-1">Day</h3>
+                  <p className="text-lg text-gray-900">Day {session.day}</p>
+                </div>
+                <div>
+                  <h3 className="text-sm font-medium text-gray-500 mb-1">Start Time</h3>
+                  <p className="text-lg text-gray-900">{formatTime(session.start_time)}</p>
+                </div>
+                <div>
+                  <h3 className="text-sm font-medium text-gray-500 mb-1">Type</h3>
+                  <p className="text-lg text-gray-900">{formatType(session.type)}</p>
+                </div>
+                {session.speaker && (
+                  <div>
+                    <h3 className="text-sm font-medium text-gray-500 mb-1">Speaker</h3>
+                    <p className="text-lg text-gray-900">{session.speaker}</p>
+                  </div>
+                )}
+                {session.location && (
+                  <div>
+                    <h3 className="text-sm font-medium text-gray-500 mb-1">Location</h3>
+                    <p className="text-lg text-gray-900">{session.location}</p>
+                  </div>
+                )}
+                {session.room && (
+                  <div>
+                    <h3 className="text-sm font-medium text-gray-500 mb-1">Room</h3>
+                    <p className="text-lg text-gray-900">{session.room}</p>
+                  </div>
+                )}
+                {session.capacity && (
+                  <div>
+                    <h3 className="text-sm font-medium text-gray-500 mb-1">Capacity</h3>
+                    <p className="text-lg text-gray-900">{session.capacity} attendees</p>
+                  </div>
+                )}
+              </div>
+
+              {session.description && (
+                <div>
+                  <h3 className="text-sm font-medium text-gray-500 mb-1">Description</h3>
+                  <p className="text-gray-900">{session.description}</p>
+                </div>
+              )}
+
+              {/* Tags */}
+              {session.tags && session.tags.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-medium text-gray-500 mb-2">Tags</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {session.tags.map(tag => (
+                      <span
+                        key={tag}
+                        className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-orange-100 text-orange-800"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Flags */}
+              <div className="flex gap-4">
+                {session.is_children_friendly && (
+                  <span className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-green-100 text-green-800">
+                    Children Friendly
+                  </span>
+                )}
+                {session.requires_registration && (
+                  <span className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800">
+                    Registration Required
+                  </span>
+                )}
+              </div>
+
+              {/* Action Buttons */}
+              <div className="flex justify-end gap-4 pt-6 border-t">
+                <button
+                  onClick={() => onDelete()}
+                  className="px-4 py-2 text-red-600 bg-red-50 rounded-lg hover:bg-red-100 transition-colors"
+                >
+                  Delete Session
+                </button>
+                <button
+                  onClick={() => onSetEditing(true)}
+                  className="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors"
+                >
+                  Edit Session
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+interface LogoProps {
+  className?: string;
+  width?: number;
+  height?: number;
+  showNavigation?: boolean;
+}
+
+const Logo: React.FC<LogoProps> = ({ 
+  className = "h-12 w-auto", 
+  width = 48, 
+  height = 48,
+  showNavigation = true 
+}) => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    if (showNavigation) {
+      router.push('/home');
+    }
+  };
+
+  return (
+    <Image 
+      src="/assets/conference-companion.png" 
+      alt="Conference Companion" 
+      width={width}
+      height={height}
+      className={`${className} ${showNavigation ? 'cursor-pointer hover:opacity-80 transition-opacity' : ''}`}
+      onClick={handleClick}
+    />
+  );
+};
+
+export default Logo; 

--- a/frontend/src/components/SessionForm.tsx
+++ b/frontend/src/components/SessionForm.tsx
@@ -1,0 +1,331 @@
+import React, { useState, useEffect } from 'react';
+
+interface SessionFormProps {
+  onSubmit: (sessionData: SessionFormData) => Promise<void>;
+  onCancel: () => void;
+  isLoading?: boolean;
+  initialData?: SessionFormData;
+}
+
+export interface SessionFormData {
+  day: number;
+  start_time: string;
+  topic: string;
+  speaker?: string;
+  description?: string;
+  type: string;
+  location?: string;
+  room?: string;
+  capacity?: number;
+  is_children_friendly: boolean;
+  requires_registration: boolean;
+  tags: string[];
+}
+
+const SESSION_TYPES = [
+  'break', 'lunch', 'talk', 'video', 'performance', 'exhibition', 
+  'panel', 'q&a', 'workshop', 'keynote', 'networking', 'registration',
+  'opening_ceremony', 'closing_ceremony', 'award_ceremony', 'demo',
+  'poster_session', 'roundtable', 'fireside_chat', 'interview'
+];
+
+export default function SessionForm({ onSubmit, onCancel, isLoading = false, initialData }: SessionFormProps) {
+  const [formData, setFormData] = useState<SessionFormData>({
+    day: 1,
+    start_time: '09:00',
+    topic: '',
+    speaker: '',
+    description: '',
+    type: 'talk',
+    location: '',
+    room: '',
+    capacity: undefined,
+    is_children_friendly: false,
+    requires_registration: false,
+    tags: []
+  });
+
+  const [tagInput, setTagInput] = useState('');
+
+  useEffect(() => {
+    if (initialData) {
+      setFormData(initialData);
+    }
+  }, [initialData]);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const { name, value, type } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: type === 'checkbox' ? (e.target as HTMLInputElement).checked : 
+              type === 'number' ? parseInt(value) || undefined : value
+    }));
+  };
+
+  const handleAddTag = () => {
+    if (tagInput.trim() && !formData.tags.includes(tagInput.trim())) {
+      setFormData(prev => ({
+        ...prev,
+        tags: [...prev.tags, tagInput.trim()]
+      }));
+      setTagInput('');
+    }
+  };
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    setFormData(prev => ({
+      ...prev,
+      tags: prev.tags.filter(tag => tag !== tagToRemove)
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await onSubmit(formData);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Day */}
+        <div>
+          <label htmlFor="day" className="block text-sm font-medium text-gray-700 mb-2">
+            Day *
+          </label>
+          <select
+            id="day"
+            name="day"
+            value={formData.day}
+            onChange={handleInputChange}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+            required
+          >
+            <option value={1}>Day 1</option>
+            <option value={2}>Day 2</option>
+            <option value={3}>Day 3</option>
+          </select>
+        </div>
+
+        {/* Start Time */}
+        <div>
+          <label htmlFor="start_time" className="block text-sm font-medium text-gray-700 mb-2">
+            Start Time *
+          </label>
+          <input
+            type="time"
+            id="start_time"
+            name="start_time"
+            value={formData.start_time}
+            onChange={handleInputChange}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+            required
+          />
+        </div>
+
+        {/* Topic */}
+        <div className="md:col-span-2">
+          <label htmlFor="topic" className="block text-sm font-medium text-gray-700 mb-2">
+            Topic *
+          </label>
+          <input
+            type="text"
+            id="topic"
+            name="topic"
+            value={formData.topic}
+            onChange={handleInputChange}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+            placeholder="Session topic"
+            required
+          />
+        </div>
+
+        {/* Speaker */}
+        <div className="md:col-span-2">
+          <label htmlFor="speaker" className="block text-sm font-medium text-gray-700 mb-2">
+            Speaker
+          </label>
+          <input
+            type="text"
+            id="speaker"
+            name="speaker"
+            value={formData.speaker}
+            onChange={handleInputChange}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+            placeholder="Speaker name"
+          />
+        </div>
+
+        {/* Type */}
+        <div>
+          <label htmlFor="type" className="block text-sm font-medium text-gray-700 mb-2">
+            Type *
+          </label>
+          <select
+            id="type"
+            name="type"
+            value={formData.type}
+            onChange={handleInputChange}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+            required
+          >
+            {SESSION_TYPES.map(type => (
+              <option key={type} value={type}>
+                {type.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase())}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Capacity */}
+        <div>
+          <label htmlFor="capacity" className="block text-sm font-medium text-gray-700 mb-2">
+            Capacity
+          </label>
+          <input
+            type="number"
+            id="capacity"
+            name="capacity"
+            value={formData.capacity || ''}
+            onChange={handleInputChange}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+            placeholder="Maximum attendees"
+            min="1"
+          />
+        </div>
+
+        {/* Location */}
+        <div>
+          <label htmlFor="location" className="block text-sm font-medium text-gray-700 mb-2">
+            Location
+          </label>
+          <input
+            type="text"
+            id="location"
+            name="location"
+            value={formData.location}
+            onChange={handleInputChange}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+            placeholder="General location"
+          />
+        </div>
+
+        {/* Room */}
+        <div>
+          <label htmlFor="room" className="block text-sm font-medium text-gray-700 mb-2">
+            Room
+          </label>
+          <input
+            type="text"
+            id="room"
+            name="room"
+            value={formData.room}
+            onChange={handleInputChange}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+            placeholder="Specific room"
+          />
+        </div>
+      </div>
+
+      {/* Description */}
+      <div>
+        <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-2">
+          Description
+        </label>
+        <textarea
+          id="description"
+          name="description"
+          value={formData.description}
+          onChange={handleInputChange}
+          rows={4}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent resize-none"
+          placeholder="Session description"
+        />
+      </div>
+
+      {/* Tags */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Tags
+        </label>
+        <div className="flex gap-2 mb-2">
+          <input
+            type="text"
+            value={tagInput}
+            onChange={(e) => setTagInput(e.target.value)}
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+            placeholder="Add a tag"
+            onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), handleAddTag())}
+          />
+          <button
+            type="button"
+            onClick={handleAddTag}
+            className="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors"
+          >
+            Add
+          </button>
+        </div>
+        {formData.tags.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {formData.tags.map(tag => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-orange-100 text-orange-800"
+              >
+                {tag}
+                <button
+                  type="button"
+                  onClick={() => handleRemoveTag(tag)}
+                  className="ml-2 text-orange-600 hover:text-orange-800"
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Checkboxes */}
+      <div className="flex gap-6">
+        <label className="flex items-center">
+          <input
+            type="checkbox"
+            name="is_children_friendly"
+            checked={formData.is_children_friendly}
+            onChange={handleInputChange}
+            className="rounded border-gray-300 text-orange-600 focus:ring-orange-500"
+          />
+          <span className="ml-2 text-sm text-gray-700">Children Friendly</span>
+        </label>
+        <label className="flex items-center">
+          <input
+            type="checkbox"
+            name="requires_registration"
+            checked={formData.requires_registration}
+            onChange={handleInputChange}
+            className="rounded border-gray-300 text-orange-600 focus:ring-orange-500"
+          />
+          <span className="ml-2 text-sm text-gray-700">Requires Registration</span>
+        </label>
+      </div>
+
+      {/* Buttons */}
+      <div className="flex justify-end gap-4">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 text-gray-700 bg-gray-200 rounded-lg hover:bg-gray-300 transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors disabled:opacity-50"
+        >
+          {isLoading ? 'Saving...' : (initialData ? 'Update Session' : 'Create Session')}
+        </button>
+      </div>
+    </form>
+  );
+} 

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -71,3 +71,40 @@ export interface SessionGroup {
 }
 
 export type TimelineItem = SessionGroup | { type: 'break'; data: Session } | { type: 'lunch'; data: Session }; 
+
+export interface PopularBooth {
+  name: string;
+  visits: number;
+}
+
+export interface PopularSessionType {
+  type: string;
+  count: number;
+}
+
+export interface AdminMetrics {
+  totalUsers: number;
+  completedUsers: number;
+  activeUsers: number;
+  completionRate: number;
+  activeRate: number;
+  popularBooths: PopularBooth[];
+  popularSessionTypes: PopularSessionType[];
+  totalSessions: number;
+  totalBooths: number;
+}
+
+export interface SessionFormData {
+  day: number;
+  start_time: string;
+  topic: string;
+  speaker?: string;
+  description?: string;
+  type: string;
+  location?: string;
+  room?: string;
+  capacity?: number;
+  is_children_friendly: boolean;
+  requires_registration: boolean;
+  tags: string[];
+} 


### PR DESCRIPTION
## What's new

- Adds a new "Sessions" tab to the admin panel, visually consistent with the Booths tab
- Allows admins to view, create, update, and delete sessions with full CRUD functionality
- Implements a blurred background for the session modal, matching other modals in the app
- After editing a session, the modal and session list update immediately to reflect changes (no need to refresh)
- Uses Supabase Edge Functions for all session CRUD operations with proper admin authorization
- Fixes RLS issues by using the service role key for backend operations

## Technical details

- **Backend**: New Supabase functions (`createSession`, `updateSession`, `deleteSession`)
- **Frontend**: New API routes, `AdminSessionModal`, `SessionForm` components
- **Admin Page**: Enhanced with sessions management tab and real-time updates
- **Database**: Proper validation and constraints for session data

## How it works

- Admins can manage all sessions from the new tab
- Editing a session opens a form; saving updates the UI instantly
- Modal background is blurred for a modern, consistent look
- All operations require admin authentication

## Why

- Improves admin workflow and UX for managing conference sessions
- Ensures data consistency and immediate feedback after edits
- Keeps UI/UX consistent across all admin modals
- Provides complete session management capabilities